### PR TITLE
helicopters can't go in air depot / fixed

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -18,11 +18,11 @@ QBCore.Functions.CreateCallback("qb-garage:server:GetGarageVehicles", function(s
             if result[1] then
                 --Check vehicle type against depot type
                 for k, vehicle in pairs(result) do
-                    if category == "air" and ( QBCore.Shared.Vehicles[vehicle.vehicle].category == "helicopters" or QBCore.Shared.Vehicles[vehicle.vehicle].category == "planes" ) then
+                    if category == "air" and ( QBCore.Shared.Vehicles[vehicle.vehicle].category == "helis" or QBCore.Shared.Vehicles[vehicle.vehicle].category == "planes" ) then
                         tosend[#tosend + 1] = vehicle
                     elseif category == "sea" and QBCore.Shared.Vehicles[vehicle.vehicle].category == "boats" then
                         tosend[#tosend + 1] = vehicle
-                    elseif category == "car" and QBCore.Shared.Vehicles[vehicle.vehicle].category ~= "helicopters" and QBCore.Shared.Vehicles[vehicle.vehicle].category ~= "planes" and QBCore.Shared.Vehicles[vehicle.vehicle].category ~= "boats" then
+                    elseif category == "car" and QBCore.Shared.Vehicles[vehicle.vehicle].category ~= "helis" and QBCore.Shared.Vehicles[vehicle.vehicle].category ~= "planes" and QBCore.Shared.Vehicles[vehicle.vehicle].category ~= "boats" then
                         tosend[#tosend + 1] = vehicle
                     end
                 end


### PR DESCRIPTION
Describe Pull request
I am trying to figure it out why helicopters not going air depot ! category names are miss matching with garages.

Questions (please complete the following information):

Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] yes
Does your code fit the style guidelines? [yes/no] yes
Does your PR fit the contribution guidelines? [yes/no] yes

Check these clip for better understanding https://youtu.be/C5sw0eSZXtY